### PR TITLE
React default change, bugfix on ranging over values

### DIFF
--- a/preset.go
+++ b/preset.go
@@ -12,7 +12,7 @@ func SecurityOptionsReactJS() Policy {
 	// unsafe-inline required for react unless the follow are set in the "build":
 	// - INLINE_RUNTIME_CHUNK=false
 	// - IMAGE_INLINE_SIZE_LIMIT=false
-	securityOptions.CSP.ScriptSrc = CSPSourceOptions{Allow: true, AllowSelf: true, StrictDynamic: true}
+	securityOptions.CSP.ScriptSrc = CSPSourceOptions{Allow: true, AllowSelf: true}
 	// unsafe-inline required for react
 	securityOptions.CSP.StyleSrcAttr = CSPSourceOptions{Allow: true, AllowSelf: true, UnsafeInline: true}
 

--- a/template.go
+++ b/template.go
@@ -4,7 +4,7 @@ package cspheader
 const TemplateTextSourceOption = "" +
 	"{{ if not .Allow }}'none'{{ else }}" +
 	"{{ if .AllowSelf }}'self'{{ end }}" +
-	"{{ range $v := .Values }} $v{{ end }}" +
+	"{{ range $v := .Values }} {{$v}}{{ end }}" +
 	"{{ if .UnsafeEval }} 'unsafe-eval'{{ end }}" +
 	"{{ if .WasmUnsafeEval }} 'wasm-unsafe-eval'{{ end }}" +
 	"{{ if .UnsafeHashes }} 'unsafe-hashes'{{ end }}" +
@@ -34,10 +34,10 @@ const TemplateTextSandbox = "" +
 const TemplateTextFrameAncestorOptions = "" +
 	"{{ if not .Allow }}'none'{{ else }}" +
 	"{{ if .AllowSelf }}'self'{{ end }}" +
-	"{{ range $v := .HostSources }} $v{{ end }}" +
-	"{{ range $v := .SchemeSources }} $v{{ end }}" +
+	"{{ range $v := .HostSources }} {{$v}}{{ end }}" +
+	"{{ range $v := .SchemeSources }} {{$v}}{{ end }}" +
 	"{{ end }}" // if not .Allow
 
-const TemplateTextUnquotedOptions = "{{ range $v := .Values }}$v {{ end }}"
+const TemplateTextUnquotedOptions = "{{ range $v := .Values }}{{$v}} {{ end }}"
 
 const TemplateTextUnquotedOption = "{{ .Value }}"


### PR DESCRIPTION
This change loosens security for React _default_ options and fixes a bug where template values were not expanded for `Values` fields/options.